### PR TITLE
feat: edit env variables

### DIFF
--- a/packages/insomnia/src/ui/components/templating/variable-editor.tsx
+++ b/packages/insomnia/src/ui/components/templating/variable-editor.tsx
@@ -1,6 +1,10 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import { useFetcher, useParams, useRouteLoaderData } from 'react-router-dom';
 
+import type { Environment } from '../../../models/environment';
 import { useNunjucks } from '../../context/nunjucks/use-nunjucks';
+import { WorkspaceLoaderData } from '../../routes/workspace';
+import { createKeybindingsHandler } from '../keydown-binder';
 
 interface Props {
   defaultValue: string;
@@ -14,6 +18,29 @@ export const VariableEditor: FC<Props> = ({ onChange, defaultValue }) => {
   const [preview, setPreview] = useState('');
   const [error, setError] = useState('');
 
+  const { organizationId, projectId, workspaceId } = useParams<{ organizationId: string; projectId: string; workspaceId: string }>();
+  const updateEnvironmentFetcher = useFetcher();
+  const updateEnvironment = async (environmentId: string, patch: Partial<Environment>) => {
+    updateEnvironmentFetcher.submit({
+      patch,
+      environmentId,
+    },
+    {
+      encType: 'application/json',
+      method: 'post',
+      action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/environment/update`,
+    });
+  };
+
+  const routeData = useRouteLoaderData(
+    ':workspaceId'
+  ) as WorkspaceLoaderData;
+
+  const {
+    activeEnvironment,
+  } = routeData;
+
+  const [edits, incrementEdits] = useReducer((state: number) => state + 1, 0);
   useEffect(() => {
     let isMounted = true;
     const syncInterpolation = async () => {
@@ -32,9 +59,54 @@ export const VariableEditor: FC<Props> = ({ onChange, defaultValue }) => {
     return () => {
       isMounted = false;
     };
-  }, [handleGetRenderContext, handleRender, selected]);
+  }, [handleGetRenderContext, handleRender, selected, edits]);
 
   const isCustomTemplateSelected = !options.find(v => selected === `{{ ${v.name} }}`);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const updateKey = useMemo(() => {
+    if (isCustomTemplateSelected) {
+      return null;
+    }
+    const withoutBraces = selected.substring(3, selected.length - 3);
+    if (!withoutBraces.startsWith('_.')) {
+      console.warn(`Key must start with '_.': ${withoutBraces}`);
+      return;
+    }
+    const withoutPrefix = withoutBraces.substring(2);
+    const key = withoutPrefix.split('.');
+    if (key.length === 0) {
+      return null;
+    }
+    return key;
+  }, [isCustomTemplateSelected, selected]);
+
+  const updateVariable = async (key: string[], newValue: string) => {
+    if (newValue === preview) {
+      return;
+    }
+
+    const keyCopy = [...key];
+    const first = keyCopy.pop();
+    if (!first) {
+      return;
+    }
+    let data: Record<string, any> = { [first]: newValue };
+    while (keyCopy.length > 0) {
+      const key = keyCopy.pop();
+      if (!key) {
+        break;
+      }
+      data = { [key]: data };
+    }
+
+    // TODO: This is _replacing_ the environment, removing all existing values
+    await updateEnvironment(activeEnvironment._id, {
+      data: data,
+    });
+  };
+
   return (
     <div>
       <div className="form-control form-control--outlined">
@@ -74,6 +146,30 @@ export const VariableEditor: FC<Props> = ({ onChange, defaultValue }) => {
           <textarea className={`${error ? 'danger' : ''}`} value={preview || error} readOnly />
         </label>
       </div>
+      {updateKey && (
+        <div className="form-control form-control--outlined">
+          <label>
+            Update value (Enter to save)
+            <input
+              ref={inputRef}
+              type="text"
+              title="Update value"
+              onKeyDown={createKeybindingsHandler({
+                'Enter': e => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  const newValue = inputRef.current?.value;
+                  if (newValue) {
+                    updateVariable(updateKey, newValue).then(() => {
+                      setTimeout(() => incrementEdits());
+                    });
+                  }
+                },
+              })}
+            />
+          </label>
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/insomnia/src/ui/components/templating/variable-editor.tsx
+++ b/packages/insomnia/src/ui/components/templating/variable-editor.tsx
@@ -87,23 +87,26 @@ export const VariableEditor: FC<Props> = ({ onChange, defaultValue }) => {
       return;
     }
 
+    // TODO: is there a built in way to set a field in an object with the JSON path?
+    const data = { ...activeEnvironment.data };
     const keyCopy = [...key];
-    const first = keyCopy.pop();
-    if (!first) {
+    const last = keyCopy.pop();
+    if (!last) {
       return;
     }
-    let data: Record<string, any> = { [first]: newValue };
+    let cur: Record<string, any> = data;
     while (keyCopy.length > 0) {
       const key = keyCopy.pop();
       if (!key) {
         break;
       }
-      data = { [key]: data };
+      cur = cur[key];
     }
+    cur[last] = newValue;
 
-    // TODO: This is _replacing_ the environment, removing all existing values
     await updateEnvironment(activeEnvironment._id, {
       data: data,
+      dataPropertyOrder: activeEnvironment.dataPropertyOrder,
     });
   };
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

- [ ] detect if the selected variable is templated and hide the edit field
- [x] update the environment correctly, to only edit that one value and not remove the other existing values
- [ ] figure out the timing to update the live preview. After the update, the next get sometimes still has the old value. I added a `setTimeout` which _usually_ works but is pretty hacky.
- [ ] Preserve the types when updating. Right now, it converts everything to a string
